### PR TITLE
Incorrect LDFLAGS for 64-bit link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,8 @@ DMOD_LDFLAGS = \
 	-Wl,-zdefs \
 	-Wl,-zignore \
 	-Wl,-M$(MDB_SOURCE)/common/modules/conf/mapfile-extern \
-	-L$(PROTO_AREA)/lib \
-	-L$(PROTO_AREA)/usr/lib
+	-L$(PROTO_AREA)/lib/amd64 \
+	-L$(PROTO_AREA)/usr/lib/amd64
 
 DMOD_LIBS = \
 	-lc


### PR DESCRIPTION
Having recently fixed the toolchain so that `-zassert-deflib` works properly for 64-bit objects, illumos-kvm fails to build with:

```
/opt/gcc-7/bin/gcc -Wl,-Bdirect -Wl,-zfatal-warnings -Wl,-zassert-deflib -Wl,-zguidance -m64 -shared -nodefaultlibs -std=gnu89 -Wl,-M/data/omnios-build/omniosorg/bloody/illumos/usr/src/common/mapfiles/common/map.pagealign -Wl,-M/data/omnios-build/omniosorg/bloody/illumos/usr/src/common/mapfiles/common/map.noexdata -Wl,-ztext -Wl,-zdefs -Wl,-zignore -Wl,-M/data/omnios-build/omniosorg/bloody/illumos/usr/src/cmd/mdb/common/modules/conf/mapfile-extern -L/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/lib -L/data/omnios-build/omniosorg/bloody/illumos/proto/root_i386/usr/lib -o kvm.so kvm_mdb.o -lc
ld: warning: dynamic library found on default search path (/lib/amd64): libc.so
collect2: error: ld returned 1 exit status
```